### PR TITLE
fix #7 - ImportError: cannot import name 'escape' from 'jinja2'

### DIFF
--- a/services/bar/requirements.txt
+++ b/services/bar/requirements.txt
@@ -1,7 +1,7 @@
-Flask==1.1.2 
-opentelemetry-api==1.0.0
-opentelemetry-sdk==1.0.0
-opentelemetry-exporter-otlp==1.0.0
-opentelemetry-instrumentation-flask==0.19b0
-opentelemetry-instrumentation-requests==0.19b0
+Flask==2.2.2
+opentelemetry-api==1.13.0
+opentelemetry-sdk==1.13.0
+opentelemetry-exporter-otlp==1.13.0
+opentelemetry-instrumentation-flask==0.34b0
+opentelemetry-instrumentation-requests==0.34b0
 requests==2.22.0

--- a/services/foo/requirements.txt
+++ b/services/foo/requirements.txt
@@ -1,7 +1,7 @@
-Flask==1.1.2 
-opentelemetry-api==1.0.0
-opentelemetry-sdk==1.0.0
-opentelemetry-exporter-otlp==1.0.0
-opentelemetry-instrumentation-flask==0.19b0
-opentelemetry-instrumentation-requests==0.19b0
+Flask==2.2.2
+opentelemetry-api==1.13.0
+opentelemetry-sdk==1.13.0
+opentelemetry-exporter-otlp==1.13.0
+opentelemetry-instrumentation-flask==0.34b0
+opentelemetry-instrumentation-requests==0.34b0
 requests==2.22.0


### PR DESCRIPTION
Fix the error every SE has to go through when joining Grafana ;)

Signed-off-by: Sebastian Schubert <basti@schubert.digital>